### PR TITLE
re #12 allow exact matching of email domains to disposable email list.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,8 +22,6 @@ matrix:
       env: TOXENV=django110-py34
     - python: 3.4
       env: TOXENV=django111-py34
-    - python: 3.4
-      env: TOXENV=django20-py34
     - python: 3.5
       env: TOXENV=django18-py35
     - python: 3.5

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,39 @@
 
 language: python
 
+matrix:
+  include:
+    - python: 2.7
+      env: TOXENV=django18-py27
+    - python: 2.7
+      env: TOXENV=django19-py27
+    - python: 2.7
+      env: TOXENV=django110-py27
+    - python: 2.7
+      env: TOXENV=django111-py27
+    - python: 3.3
+      env: TOXENV=django18-py33
+    - python: 3.4
+      env: TOXENV=django18-py34
+    - python: 3.4
+      env: TOXENV=django19-py34
+    - python: 3.4
+      env: TOXENV=django110-py34
+    - python: 3.4
+      env: TOXENV=django111-py34
+    - python: 3.4
+      env: TOXENV=django20-py34
+    - python: 3.5
+      env: TOXENV=django18-py35
+    - python: 3.5
+      env: TOXENV=django19-py35
+    - python: 3.5
+      env: TOXENV=django110-py35
+    - python: 3.5
+      env: TOXENV=django111-py35
+    - python: 3.6
+      env: TOXENV=django111-py36
+
 before_install:
   - pip install codecov tox
 
@@ -10,18 +43,6 @@ install: pip install -r requirements-test.txt
 
 # command to run tests using coverage, e.g. python setup.py test
 script: tox
-
-env:
-  - TOXENV=django18-py27
-  - TOXENV=django19-py27
-  - TOXENV=django110-py27
-  - TOXENV=django18-py33
-  - TOXENV=django18-py34
-  - TOXENV=django19-py34
-  - TOXENV=django110-py34
-  - TOXENV=django18-py35
-  - TOXENV=django19-py35
-  - TOXENV=django110-py35
 
 after_success:
   - codecov

--- a/README.md
+++ b/README.md
@@ -59,6 +59,22 @@ left blank it will default to `_('Blocked email provider.')`):
 BDEA_MESSAGE = '<blocked email message>'
 ```
 
+There are two modes for emailing matching to determine if the email is considered disposable:
+* Ending with domain
+* Exactly matching domain
+
+For example consider the email address `fake.mcfakerston@edropmail.me` if ending with domain is 
+chosen the `dropmail.me` domain will match the email address as it ends with `dropmail.me` and be
+considered as a disposable email address. If the exactly matching domain is chosen `edropmail.me` 
+does not equal `dropmain.me` and it will not be considered a disposable email address.
+
+By default the option of ending with the domain is used.
+
+To enable exact domain matching add the following to your Django settings:
+```python
+DEC_MATCHING = 'EXACT'
+```
+
 Adding to your models
 ---------------------
 

--- a/disposable_email_checker/validators.py
+++ b/disposable_email_checker/validators.py
@@ -58,8 +58,14 @@ class DisposableEmailChecker():
             there was an error contacting BDEA's servers or we did not get a
             hit on BDEA. Basically always check using local list as a backup
             """
+            start_regex = '(.*'
+            base_regex = "$)|(.*"
+            if getattr(settings, 'DEC_MATCHING', False) == 'EXACT':
+                start_regex += '@'
+                base_regex += '@'
+
             for email_group in self.chunk(self.emails, 20):
-                regex = "(.*" + "$)|(.*".join(email_group) + "$)"
+                regex = start_regex + base_regex.join(email_group) + "$)"
                 if re.match(regex, value):
                     raise ValidationError(self.message, code=self.code)
 
@@ -71,5 +77,6 @@ class DisposableEmailChecker():
 
     def chunk(self, l, n):
         return (l[i:i+n] for i in range(0, len(l), n))
+
 
 validate_disposable_email = DisposableEmailChecker()

--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -16,9 +16,25 @@ class TestDisposableEmailValidator(TestCase):
         )
         self.not_a_disposable_email = "sergey.brin@google.com"
 
+        self.ends_with_disposable_email = "fake.mcfakerston@a{domain}".format(
+            domain=random.choice(email_domain_loader())
+        )
+
     def test_validator(self):
-        self.assertRaises(ValidationError, validators.validate_disposable_email, self.disposable_email)
+        self.assertRaises(
+            ValidationError,
+            validators.validate_disposable_email,
+            self.disposable_email
+        )
         validators.validate_disposable_email(self.not_a_disposable_email)
+
+        self.assertRaises(
+            ValidationError,
+            validators.validate_disposable_email,
+            self.ends_with_disposable_email
+        )
+        with self.settings(DEC_MATCHING='EXACT'):
+            self.assertIsNone(validators.validate_disposable_email(self.ends_with_disposable_email))
 
     def test_validator_messages(self):
         with self.assertRaisesMessage(ValidationError, 'Blocked email provider.'):

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = django{18,19,110}-py{27,34,35}, django18-py33
+envlist = django{18,19,110,111}-py{27,34,35}, django111-py36, django18-py33
 
 
 [testenv]
@@ -8,6 +8,7 @@ basepython =
     py33: python3.3
     py34: python3.4
     py35: python3.5
+    py36: python3.6
 setenv =
     PYTHONPATH = {toxinidir}:{toxinidir}/disposable_email_checker
 commands = coverage run --source disposable_email_checker runtests.py
@@ -15,4 +16,5 @@ deps =
     django18: django>=1.8,<1.9
     django19: django>=1.9,<1.10
     django110: django>=1.10,<1.11
+    django111: django>=1.11,<2
     -r{toxinidir}/requirements-test.txt


### PR DESCRIPTION
In the past emails were considered disposable if the domain ended with
one of the domain in the black list. This adds the option to make it an
explicit match on the domain. By default it uses the old behaviour for
backward compatability.